### PR TITLE
Adding in support for partial queries

### DIFF
--- a/packages/apollo-boost/package-lock.json
+++ b/packages/apollo-boost/package-lock.json
@@ -14,8 +14,7 @@
           "version": "file:../apollo-utilities",
           "bundled": true,
           "requires": {
-            "fast-json-stable-stringify": "2.0.0",
-            "fclone": "1.0.11"
+            "fast-json-stable-stringify": "2.0.0"
           },
           "dependencies": {
             "fast-json-stable-stringify": {
@@ -34,7 +33,8 @@
       "version": "file:../apollo-cache-inmemory",
       "requires": {
         "apollo-cache": "file:../apollo-cache",
-        "apollo-utilities": "file:../apollo-utilities"
+        "apollo-utilities": "file:../apollo-utilities",
+        "optimism": "0.6.8"
       },
       "dependencies": {
         "apollo-cache": {
@@ -48,19 +48,9 @@
               "version": "file:../apollo-utilities",
               "bundled": true,
               "requires": {
-                "fast-json-stable-stringify": "2.0.0",
-                "fclone": "1.0.11"
+                "fast-json-stable-stringify": "2.0.0"
               },
-              "dependencies": {
-                "fast-json-stable-stringify": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
-                "fclone": {
-                  "version": "1.0.11",
-                  "bundled": true
-                }
-              }
+              "dependencies": {}
             }
           }
         },
@@ -68,8 +58,7 @@
           "version": "file:../apollo-utilities",
           "bundled": true,
           "requires": {
-            "fast-json-stable-stringify": "2.0.0",
-            "fclone": "1.0.11"
+            "fast-json-stable-stringify": "2.0.0"
           },
           "dependencies": {
             "fast-json-stable-stringify": {
@@ -108,6 +97,17 @@
               }
             }
           }
+        },
+        "immutable-tuple": {
+          "version": "0.4.9",
+          "bundled": true
+        },
+        "optimism": {
+          "version": "0.6.8",
+          "bundled": true,
+          "requires": {
+            "immutable-tuple": "0.4.9"
+          }
         }
       }
     },
@@ -115,17 +115,17 @@
       "version": "file:../apollo-client",
       "requires": {
         "@types/async": "2.0.50",
-        "@types/zen-observable": "^0.8.0",
+        "@types/zen-observable": "0.8.0",
         "apollo-cache": "file:../apollo-cache",
-        "apollo-link": "^1.0.0",
-        "apollo-link-dedup": "^1.0.0",
+        "apollo-link": "1.2.3",
+        "apollo-link-dedup": "1.0.10",
         "apollo-utilities": "file:../apollo-utilities",
-        "symbol-observable": "^1.0.2",
-        "zen-observable": "^0.8.0"
+        "symbol-observable": "1.2.0",
+        "zen-observable": "0.8.9"
       },
       "dependencies": {
         "@types/async": {
-          "version": "2.0.49",
+          "version": "2.0.50",
           "bundled": true,
           "optional": true
         },
@@ -144,19 +144,9 @@
               "version": "file:../apollo-utilities",
               "bundled": true,
               "requires": {
-                "fast-json-stable-stringify": "2.0.0",
-                "fclone": "1.0.11"
+                "fast-json-stable-stringify": "2.0.0"
               },
-              "dependencies": {
-                "fast-json-stable-stringify": {
-                  "version": "2.0.0",
-                  "bundled": true
-                },
-                "fclone": {
-                  "version": "1.0.11",
-                  "bundled": true
-                }
-              }
+              "dependencies": {}
             }
           }
         },
@@ -164,6 +154,7 @@
           "version": "1.2.3",
           "bundled": true,
           "requires": {
+            "apollo-utilities": "file:../apollo-utilities",
             "zen-observable-ts": "0.8.10"
           }
         },
@@ -178,8 +169,7 @@
           "version": "file:../apollo-utilities",
           "bundled": true,
           "requires": {
-            "fast-json-stable-stringify": "2.0.0",
-            "fclone": "1.0.11"
+            "fast-json-stable-stringify": "2.0.0"
           },
           "dependencies": {
             "fast-json-stable-stringify": {
@@ -214,8 +204,8 @@
       "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.3.tgz",
       "integrity": "sha512-iL9yS2OfxYhigme5bpTbmRyC+Htt6tyo2fRMHT3K1XRL/C5IQDDz37OjpPy4ndx7WInSvfSZaaOTKFja9VWqSw==",
       "requires": {
-        "apollo-utilities": "^1.0.0",
-        "zen-observable-ts": "^0.8.10"
+        "apollo-utilities": "1.0.21",
+        "zen-observable-ts": "0.8.10"
       }
     },
     "apollo-link-error": {
@@ -223,7 +213,7 @@
       "resolved": "https://registry.npmjs.org/apollo-link-error/-/apollo-link-error-1.1.1.tgz",
       "integrity": "sha512-/yPcaQWcBdB94vpJ4FsiCJt1dAGGRm+6Tsj3wKwP+72taBH+UsGRQQZk7U/1cpZwl1yqhHZn+ZNhVOebpPcIlA==",
       "requires": {
-        "apollo-link": "^1.2.3"
+        "apollo-link": "1.2.3"
       }
     },
     "apollo-link-http": {
@@ -231,8 +221,8 @@
       "resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.5.tgz",
       "integrity": "sha512-C5N6N/mRwmepvtzO27dgMEU3MMtRKSqcljBkYNZmWwH11BxkUQ5imBLPM3V4QJXNE7NFuAQAB5PeUd4ligivTQ==",
       "requires": {
-        "apollo-link": "^1.2.3",
-        "apollo-link-http-common": "^0.2.5"
+        "apollo-link": "1.2.3",
+        "apollo-link-http-common": "0.2.5"
       }
     },
     "apollo-link-http-common": {
@@ -240,7 +230,7 @@
       "resolved": "https://registry.npmjs.org/apollo-link-http-common/-/apollo-link-http-common-0.2.5.tgz",
       "integrity": "sha512-6FV1wr5AqAyJ64Em1dq5hhGgiyxZE383VJQmhIoDVc3MyNcFL92TkhxREOs4rnH2a9X2iJMko7nodHSGLC6d8w==",
       "requires": {
-        "apollo-link": "^1.2.3"
+        "apollo-link": "1.2.3"
       }
     },
     "apollo-link-state": {
@@ -248,8 +238,8 @@
       "resolved": "https://registry.npmjs.org/apollo-link-state/-/apollo-link-state-0.4.2.tgz",
       "integrity": "sha512-xMPcAfuiPVYXaLwC6oJFIZrKgV3GmdO31Ag2eufRoXpvT0AfJZjdaPB4450Nu9TslHRePN9A3quxNueILlQxlw==",
       "requires": {
-        "apollo-utilities": "^1.0.8",
-        "graphql-anywhere": "^4.1.0-alpha.0"
+        "apollo-utilities": "1.0.21",
+        "graphql-anywhere": "4.1.19"
       }
     },
     "apollo-utilities": {
@@ -257,8 +247,8 @@
       "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.21.tgz",
       "integrity": "sha512-ZcxELlEl+sDCYBgEMdNXJAsZtRVm8wk4HIA58bMsqYfd1DSAJQEtZ93F0GZgYNAGy3QyaoBeZtbb0/01++G8JQ==",
       "requires": {
-        "fast-json-stable-stringify": "^2.0.0",
-        "fclone": "^1.0.11"
+        "fast-json-stable-stringify": "2.0.0",
+        "fclone": "1.0.11"
       },
       "dependencies": {
         "fast-json-stable-stringify": {
@@ -278,7 +268,7 @@
       "resolved": "https://registry.npmjs.org/graphql-anywhere/-/graphql-anywhere-4.1.19.tgz",
       "integrity": "sha512-mQlvbECzYPBcgBC9JsdM4v+DSvNmcIP+8Vwr+ij3gktbaLSE0Iza30mztuz40Jlf7ooMs+0emBZucNjLzqz7tA==",
       "requires": {
-        "apollo-utilities": "^1.0.21"
+        "apollo-utilities": "1.0.21"
       }
     },
     "graphql-tag": {
@@ -296,7 +286,7 @@
       "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.10.tgz",
       "integrity": "sha512-5vqMtRggU/2GhePC9OU4sYEWOdvmayp2k3gjPf4F0mXwB3CSbbNznfDUvDJx9O2ZTa1EIXdJhPchQveFKwNXPQ==",
       "requires": {
-        "zen-observable": "^0.8.0"
+        "zen-observable": "0.8.9"
       }
     }
   }

--- a/packages/apollo-cache-inmemory/package-lock.json
+++ b/packages/apollo-cache-inmemory/package-lock.json
@@ -14,8 +14,7 @@
           "version": "file:../apollo-utilities",
           "bundled": true,
           "requires": {
-            "fast-json-stable-stringify": "^2.0.0",
-            "fclone": "^1.0.11"
+            "fast-json-stable-stringify": "2.0.0"
           },
           "dependencies": {
             "fast-json-stable-stringify": {
@@ -33,7 +32,7 @@
     "apollo-utilities": {
       "version": "file:../apollo-utilities",
       "requires": {
-        "fast-json-stable-stringify": "^2.0.0"
+        "fast-json-stable-stringify": "2.0.0"
       },
       "dependencies": {
         "fast-json-stable-stringify": {
@@ -56,7 +55,7 @@
       "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.6.6.tgz",
       "integrity": "sha512-1Y6LY7pYbXP5y6yeXYfXhxJi9hsxYAZWpt7bBp4seAwfcYtaN7tq9wot/pdrhyI809/K4gDm3BcZcEkmwGevjg==",
       "requires": {
-        "immutable-tuple": "^0.4.4"
+        "immutable-tuple": "0.4.8"
       }
     }
   }

--- a/packages/apollo-cache-inmemory/src/readFromStore.ts
+++ b/packages/apollo-cache-inmemory/src/readFromStore.ts
@@ -71,7 +71,7 @@ export type ExecResultMissingField = {
   object: StoreObject;
   fieldName: string;
   tolerable: boolean;
-  selection: FieldNode;
+  selection: SelectionNode;
 };
 
 export type ExecResult<R = any> = {
@@ -264,7 +264,7 @@ export class StoreReader {
     };
   }
   private partitionQuery(
-    fields: FieldNode[],
+    missingSelections: SelectionNode[],
     {
       query,
       rootValue,
@@ -295,7 +295,7 @@ export class StoreReader {
             mainDefinition.selectionSet,
             rootValue,
             execContext,
-            fields,
+            missingSelections,
           ),
         },
         ...fragments,
@@ -311,7 +311,7 @@ export class StoreReader {
       variableValues: any;
       contextValue: ReadStoreContext;
     },
-    fields: FieldNode[],
+    missingSelections: SelectionNode[],
   ): SelectionSetNode {
     const { fragmentMap, variableValues: variables } = execContext;
 
@@ -327,13 +327,13 @@ export class StoreReader {
       if (isField(selection)) {
         if (!selection.selectionSet) {
           // Handle scalar selections
-          if (fields.indexOf(selection) !== -1) {
+          if (missingSelections.indexOf(selection) !== -1) {
             resultSelectionsSet.selections.push(selection);
           }
         } else {
           // In the case of subselections, if the parent is in the missing list, traversing through the
           // subfields is pointless, hence inserting the parent and continuing.
-          if (fields.indexOf(selection) !== -1) {
+          if (missingSelections.indexOf(selection) !== -1) {
             resultSelectionsSet.selections.push(selection);
           } else {
             // If parent is not listed as missing, we still need to check the subfields, hence checking those here.
@@ -341,7 +341,7 @@ export class StoreReader {
               selection.selectionSet,
               rootValue,
               execContext,
-              fields,
+              missingSelections,
             );
             // If there are no  missing subselections found avoid adding the parent.
             if (selectionToInsert.selections.length > 0) {
@@ -379,7 +379,7 @@ export class StoreReader {
             fragment.selectionSet,
             rootValue,
             execContext,
-            fields,
+            missingSelections,
           );
           resultSelectionsSet.selections = resultSelectionsSet.selections.concat(
             selectionsToInsert.selections,

--- a/packages/apollo-cache/package-lock.json
+++ b/packages/apollo-cache/package-lock.json
@@ -7,7 +7,7 @@
     "apollo-utilities": {
       "version": "file:../apollo-utilities",
       "requires": {
-        "fast-json-stable-stringify": "^2.0.0"
+        "fast-json-stable-stringify": "2.0.0"
       },
       "dependencies": {
         "fast-json-stable-stringify": {

--- a/packages/apollo-cache/src/types/DataProxy.ts
+++ b/packages/apollo-cache/src/types/DataProxy.ts
@@ -73,6 +73,7 @@ export namespace DataProxy {
   export type DiffResult<T> = {
     result?: T;
     complete?: boolean;
+    partitionedQuery?: any;
   };
 }
 

--- a/packages/apollo-client/package-lock.json
+++ b/packages/apollo-client/package-lock.json
@@ -25,8 +25,7 @@
           "version": "file:../apollo-utilities",
           "bundled": true,
           "requires": {
-            "fast-json-stable-stringify": "2.0.0",
-            "fclone": "1.0.11"
+            "fast-json-stable-stringify": "2.0.0"
           },
           "dependencies": {
             "fast-json-stable-stringify": {
@@ -46,8 +45,8 @@
       "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.3.tgz",
       "integrity": "sha512-iL9yS2OfxYhigme5bpTbmRyC+Htt6tyo2fRMHT3K1XRL/C5IQDDz37OjpPy4ndx7WInSvfSZaaOTKFja9VWqSw==",
       "requires": {
-        "apollo-utilities": "^1.0.0",
-        "zen-observable-ts": "^0.8.10"
+        "apollo-utilities": "1.0.25",
+        "zen-observable-ts": "0.8.10"
       },
       "dependencies": {
         "apollo-utilities": {
@@ -55,7 +54,7 @@
           "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.25.tgz",
           "integrity": "sha512-AXvqkhni3Ir1ffm4SA1QzXn8k8I5BBl4PVKEyak734i4jFdp+xgfUyi2VCqF64TJlFTA/B73TRDUvO2D+tKtZg==",
           "requires": {
-            "fast-json-stable-stringify": "^2.0.0"
+            "fast-json-stable-stringify": "2.0.0"
           }
         }
       }
@@ -65,13 +64,13 @@
       "resolved": "https://registry.npmjs.org/apollo-link-dedup/-/apollo-link-dedup-1.0.10.tgz",
       "integrity": "sha512-tpUI9lMZsidxdNygSY1FxflXEkUZnvKRkMUsXXuQUNoSLeNtEvUX7QtKRAl4k9ubLl8JKKc9X3L3onAFeGTK8w==",
       "requires": {
-        "apollo-link": "^1.2.3"
+        "apollo-link": "1.2.3"
       }
     },
     "apollo-utilities": {
       "version": "file:../apollo-utilities",
       "requires": {
-        "fast-json-stable-stringify": "^2.0.0"
+        "fast-json-stable-stringify": "2.0.0"
       },
       "dependencies": {
         "fast-json-stable-stringify": {
@@ -104,7 +103,7 @@
       "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.10.tgz",
       "integrity": "sha512-5vqMtRggU/2GhePC9OU4sYEWOdvmayp2k3gjPf4F0mXwB3CSbbNznfDUvDJx9O2ZTa1EIXdJhPchQveFKwNXPQ==",
       "requires": {
-        "zen-observable": "^0.8.0"
+        "zen-observable": "0.8.9"
       }
     }
   }

--- a/packages/graphql-anywhere/package-lock.json
+++ b/packages/graphql-anywhere/package-lock.json
@@ -7,7 +7,7 @@
     "apollo-utilities": {
       "version": "file:../apollo-utilities",
       "requires": {
-        "fast-json-stable-stringify": "^2.0.0"
+        "fast-json-stable-stringify": "2.0.0"
       },
       "dependencies": {
         "fast-json-stable-stringify": {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Client!

  A few automated bots may chime in on your PR. They are here to help
  with reviewing and ensuring Apollo Client is production ready after each
  pull request merge.

    - meteor-bot will respond asking you to sign the CLA if this is your first PR.
      It may also respond with warnings, messages, or fail the build if something is off.
      Don't worry, it'll help you to fix what is broken!

    - bundlesize is a status check to keep the footprint of Apollo Client as small as possible.

    - travis-ci will run tests, checking style of code, and generally make
      sure everything is working as expected

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
# Query Partitioning 

The goal of this item is to try and figure out an effective way in which queries can be partitioned into subqueries in order to limit load on servers. Below is an example 

Lets say that the following query is first issued
``` 
chats {
  members {
    displayName
    email
  }
  properties {
    foo
    bar
  }
}
```

As a secondary query in order to resolve some other part of the UI we end up issuing a query like so 
```
chats {
  members {
    displayName
    email
  }
  topic // NEW FIELD
  properties {
    foo
    bar
  }
}
```
Now lets say the following is the size of the properties 
```
chats {
  members { // 1MB
    displayName
    email
  }
  topic // NEW FIELD (12 Bytes)
  properties { // 512KB
    foo
    bar
  }
}
```

The current apollo cache works as follows: 

```
const isComplete = diffQueryAgainstStore(query);
if (!isComplete) {
  return fetchRequest(query).then(result = {
    addToStore(query, result);
    return result;
;  });
}
```

Thus the entire query will be re-issued and a fetch would be made to get 1.5MB of data when all that is needed is 12 bytes. 

This particular implementation in review will instead attempt do something like so 
```
const { isComplete, partitionedQuery, storeResult } = diffQueryAgainstStore(query);
if(!isComplete) {
  return fetchRequest(partitionedQuery).then (() => {
    if (partitionedQuery !== query) {
      merge(result, storeResult);
      addToStore(query, result);
      return result;
    }
  });
}

```

where partitionedQuery is something like this
```
chats {
  topic // Only 12 bytes
}
```

## makeExecutableSchema backed selections:

Another benefit while executing the above sort of strategy lies with makeExecutableSchema backed local clients. 

The logic for makeExecutableSchema is something like below
```
1. Parse field from response
2. Compare if required in selection
3. Add field to result if type and subtypes match
4. Recurse for every field
```

This process can get expensive when iterating through larger responses like the ones indicated above. 
By reducing the `selectionSet` that is requested we ensure that lesser time is spent in doing the above logic. 

> NOTE: It may be that the underlying network call to fetch the topic() property is non trivial and actually requires getting all the payload, but this is something that can be optimized at the resolver/network layer by writing more efficient resolvers/reducing traffic


## Changes required
1. __ApolloClient/QueryManager__: 
The intial set of changes required here would be to allow passing/merging results from the partitioned queries. 
2. __Store/Caching layer__: Should return the partitioned query for fields that are missing as part of the `isComplete` flag. A new result should be present as part of the `diff` method that is there in the `ApolloCache` interface
3. __Tests__: To make sure all of the above works (WIP)

### Checklist:

- [X] If this PR is a new feature, please reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
